### PR TITLE
Demonstrate Reference in Rust

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,9 @@ path = "src/stack-heap.rs"
 name = "ownership"          
 path = "src/ownership.rs"
 
+[[bin]]
+name = "reference"          
+path = "src/reference.rs"
 
 [dependencies]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,9 +29,11 @@ path = "src/stack-heap.rs"
 name = "ownership"          
 path = "src/ownership.rs"
 
+
 [[bin]]
 name = "reference"          
 path = "src/reference.rs"
+
 
 [dependencies]
 

--- a/src/reference.rs
+++ b/src/reference.rs
@@ -1,0 +1,6 @@
+fn main(){
+    let s1 = String::from("hello");
+    let s2 = &s1;
+    println!("{}",s2);
+    println!("{}",s1); // This is valid, The first pointer wasn't invalidated
+}

--- a/src/reference.rs
+++ b/src/reference.rs
@@ -2,5 +2,5 @@ fn main(){
     let s1 = String::from("hello");
     let s2 = &s1;
     println!("{}",s2);
-    println!("{}",s1); // This is valid, The first pointer wasn't invalidated
+    println!("{}",s1); // This is valid because of reference, The first pointer wasn't invalidated
 }


### PR DESCRIPTION
**Description:**
This commit demonstrates referencing in Rust using immutable references. The example highlights how references work, and how Rust's memory management system ensures that the original data remains valid while being referenced.
 
**Key Changes:**
- **Reference with Immutable References:**
  - Added a new file `src/reference.rs` that demonstrates referencing in Rust.
  - The code uses a reference `s2` to borrow the value of `s1`, showcasing how referencing works without invalidating the original variable.
  - The program prints the value of `s2` and `s1`, demonstrating that both can be used safely while `s2` references `s1`.
 
- **Cargo Configuration:**
  - Registered the new binary `reference` in `Cargo.toml`.
 
**Files Changed:**
 
- **`src/reference.rs`:**
  - Implemented a simple program demonstrating the concept of referencing using immutable references in Rust.
- **`Cargo.toml`:**
  - Registered the new binary `reference` for the project.
**How to Test:**
Run the `reference` binary:
```bash
cargo run --bin reference
```
 
**Expected Output:**
```txt
hello
hello
```
 
**Summary:**
This commit introduces the concept of referencing in Rust, where an immutable reference allows access to data without invalidating the original variable. The example helps clarify how Rust ensures memory safety without the need for garbage collection.