### PR TITLE
Demonstrate Borrowing and Immutable References in Rust

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ path = "src/reference.rs"
 name = "borrowing"          
 path = "src/borrowing.rs"
 
+
 [dependencies]
 
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,10 @@ name = "reference"
 path = "src/reference.rs"
 
 
+[[bin]]
+name = "borrowing"          
+path = "src/borrowing.rs"
+
 [dependencies]
 
 

--- a/src/borrowing.rs
+++ b/src/borrowing.rs
@@ -14,4 +14,4 @@ fn main() {
 
 fn takes_ownership(some_string: &String) {
     println!("{}", some_string);  // some_string is borrowed and not moved
-}
+} 

--- a/src/borrowing.rs
+++ b/src/borrowing.rs
@@ -1,0 +1,17 @@
+fn main() {
+    let my_string = String::from("Hello, Rust!");
+    takes_ownership(&my_string);  // Pass a reference to my_string
+    println!("{}", my_string);    // This is valid because ownership was not transferred
+
+    let s1 = String::from("Hello");
+    let s2 = &s1;
+    let s3 = &s1;
+    
+    println!("{}", s1); //There can be many immutable references at the same time
+    println!("{}", s2);
+    println!("{}", s3);
+}
+
+fn takes_ownership(some_string: &String) {
+    println!("{}", some_string);  // some_string is borrowed and not moved
+}


### PR DESCRIPTION
**Description:**
This pull request introduces a new example demonstrating borrowing and immutable references in Rust. The code highlights Rust's ownership system, showing how references work without transferring ownership and how multiple immutable references can safely coexist. This example is designed to clarify key concepts in Rust's memory management, ensuring data safety and efficient resource handling.

**Key Changes:**

- **Implementation of Borrowing Example:**
  - Created a new file, `src/borrowing.rs`, containing a program that demonstrates:
    - Borrowing with immutable references: Passing a reference to a function without transferring ownership.
    - The ability to have multiple immutable references (`s2`, `s3`) to the same data (`s1`) simultaneously.
    - Printing the values of both the original variable and its references to demonstrate safety and validity.

- **Cargo Configuration:**
  - Updated `Cargo.toml` to register the new binary `borrowing` for the project.

**Files Changed:**

1. **`src/borrowing.rs`:**
   - Implemented the example with the following components:
     - **Main Function:** Demonstrates passing a reference (`my_string`) to the `takes_ownership` function, which prints the borrowed value without transferring ownership. Also demonstrates creating multiple immutable references (`s2`, `s3`) to a single variable (`s1`) and safely using them all.
     - **Function `takes_ownership`:** Accepts an immutable reference to a string and prints it, illustrating how functions can borrow data without taking ownership.
     
2. **`Cargo.toml`:**
   - Added the following entry for the new binary:
     ```toml
     [[bin]]
     name = "borrowing"
     path = "src/borrowing.rs"
     ```
**How to Test:**
1. Build and run the `borrowing` binary:
   ```bash
   cargo run --bin borrowing
   ```

2. Verify the output matches the following:
   ```txt
   Hello, Rust!
   Hello, Rust!
   Hello
   Hello
   Hello
   ```

**Expected Behavior:**
- The original string (`my_string`) remains valid after being borrowed by the `takes_ownership` function.
- Multiple immutable references (`s2`, `s3`) coexist with the original variable (`s1`) without any conflicts.

**Summary:**
This pull request provides a practical example of borrowing and immutable references in Rust. By demonstrating how references work without transferring ownership, and how multiple immutable references can be safely used, this example helps  better to understand Rust's ownership model and memory safety features.
